### PR TITLE
no not show the menu items "view source", "save", and "zoom" for the new tab page (empty url)

### DIFF
--- a/src/app/webbrowser/Browser.qml
+++ b/src/app/webbrowser/Browser.qml
@@ -780,14 +780,14 @@ Common.BrowserView {
                 objectName: "view source"
                 text: i18n.tr("View source")
                 iconName: "text-xml-symbolic"
-                enabled: currentWebview && (currentWebview.url.toString().substring(0,12) !== "view-source:")
+                enabled: currentWebview && (currentWebview.url.toString() !== "") && (currentWebview.url.toString().substring(0,12) !== "view-source:")
                 onTriggered: openLinkInNewTabRequested("view-source:%1".arg(currentWebview.url), false);
             },
             Action {
                 objectName: "save"
                 text: i18n.tr("Save as HTML / PDF")
                 iconName: "save-as"
-                enabled: currentWebview
+                enabled: currentWebview && (currentWebview.url.toString() !== "")
                 onTriggered: {
                     var savePageDialog = PopupUtils.open(Qt.resolvedUrl("../SavePageDialog.qml"), currentWebview);
                     savePageDialog.saveAsHtml.connect( function() { currentWebview.triggerWebAction(WebEngineView.SavePage) } )
@@ -800,7 +800,7 @@ Common.BrowserView {
                 objectName: "zoom"
                 text: i18n.tr("Zoom")
                 iconName: "zoom-in"
-                enabled: currentWebview
+                enabled: currentWebview && (currentWebview.url.toString() !== "")
                 onTriggered: currentWebview.showZoomMenu()
             }
 

--- a/src/app/webbrowser/SettingsPage.qml
+++ b/src/app/webbrowser/SettingsPage.qml
@@ -164,9 +164,11 @@ FocusScope {
                             function formatValue(v) { return Math.round(v * 100 / 5) * 5 + "%" }
                             value: settingsObject.zoomFactor
                             onValueChanged: {
-                                // round for 5% steps (e.g. 95%, 100%)
-                                var percentValue = Math.round(value * 100 / 5) * 5
-                                settingsObject.zoomFactor = percentValue / 100
+                                if (Math.abs(value - settingsObject.zoomFactor) > 0.0001) {
+                                    // round for 5% steps (e.g. 95%, 100%)
+                                    var percentValue = Math.round(value * 100 / 5) * 5
+                                    settingsObject.zoomFactor = percentValue / 100
+                                }
                             }
                             SlotsLayout.position: SlotsLayout.Trailing
                         }

--- a/src/app/webcontainer/WebappSettingsPage.qml
+++ b/src/app/webcontainer/WebappSettingsPage.qml
@@ -84,9 +84,11 @@ FocusScope {
                             function formatValue(v) { return Math.round(v * 100 / 5) * 5 + "%" }
                             value: settingsObject.zoomFactor
                             onValueChanged: {
-                                // round for 5% steps (e.g. 95%, 100%)
-                                var percentValue = Math.round(value * 100 / 5) * 5
-                                settingsObject.zoomFactor = percentValue / 100
+                                if (Math.abs(value - settingsObject.zoomFactor) > 0.0001) {
+                                    // round for 5% steps (e.g. 95%, 100%)
+                                    var percentValue = Math.round(value * 100 / 5) * 5
+                                    settingsObject.zoomFactor = percentValue / 100
+                                }
                             }
                             SlotsLayout.position: SlotsLayout.Trailing
                         }


### PR DESCRIPTION
I've found a bug in my own code, which fits to the zoom topic:

The menu entries don't make sense for the new tab page (url of the webview is empty)